### PR TITLE
Pin `node-fetch` version to v2

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -17,5 +17,10 @@
       "matchPackageNames": ["@types/node"],
       "allowedVersions": "14.x"
     },
+    // v3 is ESM-only
+    {
+      "matchPackageNames": ["node-fetch"],
+      "allowedVersions": "2.x"
+    },
   ],
 }


### PR DESCRIPTION
@arimus we've explicitly blocked `node-fetch@3` in our renovate config in other repos since it's ESM only. This will close out the renovate PR to upgrade it.