### PR TITLE
Drop support for Node.js v14

### DIFF
--- a/.changeset/metal-beers-joke.md
+++ b/.changeset/metal-beers-joke.md
@@ -1,0 +1,5 @@
+---
+'@as-integrations/hapi': major
+---
+
+Drop support for Node.js v14

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,9 +75,9 @@ workflows:
           matrix:
             parameters:
               node-version:
-                - "14"
                 - "16"
                 - "18"
+                - "20"
       - Prettier
       - Lint
       - Spell Check

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This is a simple package that easily allows you to connect your own Hapi server 
 
 ## **Requirements**
 
-- **[Node.js v14](https://nodejs.org/)** or later
+- **[Node.js v16](https://nodejs.org/)** or later
 - **[Hapi v20.x](https://www.hapi.dev/)** or later
 - **[GraphQL.js v16](https://graphql.org/graphql-js/)** or later
 - **[Apollo Server v4](https://www.apollographql.com/docs/apollo-server/)** or later

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@changesets/cli": "2.26.1",
         "@types/hapi__hapi": "20.0.13",
         "@types/jest": "29.5.1",
-        "@types/node": "14.18.43",
+        "@types/node": "16.18.25",
         "@typescript-eslint/eslint-plugin": "5.59.2",
         "@typescript-eslint/parser": "5.59.2",
         "cspell": "6.31.1",
@@ -30,7 +30,7 @@
         "typescript": "5.0.4"
       },
       "engines": {
-        "node": ">=14.0"
+        "node": ">=16"
       },
       "peerDependencies": {
         "@apollo/server": "^4.0.0",
@@ -3662,9 +3662,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "14.18.43",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.43.tgz",
-      "integrity": "sha512-n3eFEaoem0WNwLux+k272P0+aq++5o05bA9CfiwKPdYPB5ZambWKdWoeHy7/OJiizMhzg27NLaZ6uzjLTzXceQ==",
+      "version": "16.18.25",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.25.tgz",
+      "integrity": "sha512-rUDO6s9Q/El1R1I21HG4qw/LstTHCPO/oQNAwI/4b2f9EWvMnqt4d3HJwPMawfZ3UvodB8516Yg+VAq54YM+eA==",
       "dev": true
     },
     "node_modules/@types/node-fetch": {
@@ -15184,9 +15184,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "14.18.43",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.43.tgz",
-      "integrity": "sha512-n3eFEaoem0WNwLux+k272P0+aq++5o05bA9CfiwKPdYPB5ZambWKdWoeHy7/OJiizMhzg27NLaZ6uzjLTzXceQ==",
+      "version": "16.18.25",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.25.tgz",
+      "integrity": "sha512-rUDO6s9Q/El1R1I21HG4qw/LstTHCPO/oQNAwI/4b2f9EWvMnqt4d3HJwPMawfZ3UvodB8516Yg+VAq54YM+eA==",
       "dev": true
     },
     "@types/node-fetch": {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "engines": {
-    "node": ">=14.0"
+    "node": ">=16"
   },
   "scripts": {
     "build": "tsc --build tsconfig.build.json",
@@ -42,7 +42,7 @@
     "@changesets/cli": "2.26.1",
     "@types/hapi__hapi": "20.0.13",
     "@types/jest": "29.5.1",
-    "@types/node": "14.18.43",
+    "@types/node": "16.18.25",
     "@typescript-eslint/eslint-plugin": "5.59.2",
     "@typescript-eslint/parser": "5.59.2",
     "cspell": "6.31.1",

--- a/renovate.json5
+++ b/renovate.json5
@@ -15,7 +15,7 @@
     // versions we support.
     {
       "matchPackageNames": ["@types/node"],
-      "allowedVersions": "14.x"
+      "allowedVersions": "16.x"
     },
     // v3 is ESM-only
     {


### PR DESCRIPTION
Fixes #32.

Node.js v14 is EOL as of April 30. We should drop support for it and publish a new major version.