### PR TITLE
Pass TContext type argument to ApolloServer

### DIFF
--- a/.changeset/bright-elephants-act.md
+++ b/.changeset/bright-elephants-act.md
@@ -1,0 +1,5 @@
+---
+'@as-integrations/hapi': patch
+---
+
+Pass TContext to ApolloServer in HapiApolloPluginOptions

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,7 +22,7 @@ export interface HapiContextFunctionArgument {
 }
 
 export interface HapiApolloPluginOptions<TContext extends BaseContext> {
-  apolloServer: ApolloServer;
+  apolloServer: ApolloServer<TContext>;
   context?: ContextFunction<[HapiContextFunctionArgument], TContext>;
   path?: string;
   getRoute?: {


### PR DESCRIPTION
## Context
ApolloServer is generic on the type of the context, constrained by `extends BaseContext`. `HapiApolloPluginOptions` takes the context type as a generic type parameter, but does not pass this to ApolloServer, meaning when trying to use a custom context TypeScript compilation errors can occur.

## Changes
Pass `TContext` to `ApolloServer` in `HapiApolloPluginOptions`.